### PR TITLE
git: Refer to specific commit

### DIFF
--- a/org.sparkleshare.SparkleShare.Nightly.yml
+++ b/org.sparkleshare.SparkleShare.Nightly.yml
@@ -41,6 +41,7 @@ modules:
       sources: 
           - type: git
             tag: v2.17.0
+            commit: 265941062ed3b753797a028b5cd4388131a8e9f2
             url: 'https://github.com/desktop/dugite-native'
       buildsystem: simple
       build-commands:

--- a/org.sparkleshare.SparkleShare.yml
+++ b/org.sparkleshare.SparkleShare.yml
@@ -41,6 +41,7 @@ modules:
       sources: 
           - type: git
             tag: v2.17.0
+            commit: 265941062ed3b753797a028b5cd4388131a8e9f2
             url: 'https://github.com/desktop/dugite-native'
       buildsystem: simple
       build-commands:


### PR DESCRIPTION
Tags can change, which makes just specifying a tag non-reproducible.